### PR TITLE
A few minor changes to the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,16 +11,19 @@ LINKERWF =
 SOURCES := $(wildcard src/*.cpp)
 OBJECTS := $(SOURCES:src/%.cpp=obj/%.o)
 
-compile_linux: MIDIProcessor
+.PHONY: compile_linux
+compile_linux: midiprocessor
 
+.PHONY: compile_win
 compile_win: MIDIProcessor.exe
 
-MIDIProcessor: $(OBJECTS)
+midiprocessor: $(OBJECTS)
 	@$(LINKERL) $(OBJECTS) $(LINKERLF) -o $@
 
 $(OBJECTS): obj/%.o : src/%.cpp
 	@$(CXXL) $(CXXLF) -c $< -o $@
 	
+.PHONY: clean
 clean:
 	@rm -f obj/*.o
 	@rm -f MIDIProcessor


### PR DESCRIPTION
Made the output file for Linux `midiprocessor`, Linux executable names shouldn't be capitalized since Linux is case sensitive

Also marked a few targets as `.PHONY`, this should be done for any target that doesn't actually generate a file (ie `clean`)